### PR TITLE
Add configurable noVNC launcher plugin

### DIFF
--- a/plugins/novnclauncher/CHANGELOG.md
+++ b/plugins/novnclauncher/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 0.1.0
+- Initial release with configurable noVNC launch button and query parameter templating.

--- a/plugins/novnclauncher/README.md
+++ b/plugins/novnclauncher/README.md
@@ -1,0 +1,65 @@
+# noVNC Launcher Button Plugin
+
+This plugin adds a configurable noVNC launch button to the MeshCentral device view. The button mirrors the existing `Web-VNC` link but allows additional query parameters to be appended to the generated `novnc/vnc.html` URL. This makes it possible to pre-configure features such as automatic connection, view-only mode, or other options supported by noVNC.
+
+## Installation
+
+1. Enable plugins in your `meshcentral-data/config.json` if they are not already enabled:
+   ```json
+   {
+     "plugins": {
+       "enabled": true,
+       "list": ["novnclauncher"]
+     }
+   }
+   ```
+   Alternatively you can upload the plugin bundle through **My Server → Plugins → Download Plugin**.
+2. Copy the `plugins/novnclauncher` directory into `meshcentral-data/plugins/novnclauncher`.
+3. Restart MeshCentral or refresh the plugin handler from the UI.
+4. Enable the *noVNC Launcher Button* plugin from the **My Server → Plugins** page.
+
+## Configuration
+
+The plugin reads its settings from `config.json`. The default configuration is:
+
+```json
+{
+  "settings": {
+    "buttonLabel": "Custom Web-VNC",
+    "buttonTooltip": "Launch a noVNC session with custom parameters",
+    "appendDefaultName": true,
+    "hideDefaultWebVncLink": false,
+    "windowNamePrefix": "customnovnc",
+    "queryString": "",
+    "queryParameters": {
+      "autoconnect": "true"
+    }
+  }
+}
+```
+
+* **buttonLabel** – Text shown for the new button.
+* **buttonTooltip** – Tooltip shown on hover.
+* **appendDefaultName** – When `true` the remote device name is added to the URL (same behaviour as the built-in link).
+* **hideDefaultWebVncLink** – When `true` the original `Web-VNC` link is hidden once the plugin button is rendered.
+* **windowNamePrefix** – Prefix for the browser window/tab name used for the custom session.
+* **queryString** – A raw string appended to the URL. If it does not start with `&` one is added automatically.
+* **queryParameters** – Key/value pairs converted into query parameters. Values support the placeholders `{{nodeid}}`, `{{name}}`, `{{host}}`, `{{meshid}}`, `{{meshname}}`, and `{{domainid}}`.
+
+### Example: enable view-only mode and provide a custom title
+
+```json
+{
+  "settings": {
+    "buttonLabel": "Web-VNC (View Only)",
+    "queryParameters": {
+      "view_only": "1",
+      "title": "{{meshname}} - {{name}}"
+    }
+  }
+}
+```
+
+## Usage
+
+After enabling the plugin, open any device page. When the regular `Web-VNC` link is available you will see the additional button rendered next to it. Clicking the button launches a noVNC session using the configured parameters.

--- a/plugins/novnclauncher/config.json
+++ b/plugins/novnclauncher/config.json
@@ -1,0 +1,28 @@
+{
+  "name": "noVNC Launcher Button",
+  "shortName": "novnclauncher",
+  "version": "0.1.0",
+  "author": "MeshCentral Contributors",
+  "description": "Adds a configurable button to the device view that launches noVNC sessions with custom parameters.",
+  "hasAdminPanel": false,
+  "homepage": "https://github.com/Ylianst/MeshCentral/tree/master/plugins/novnclauncher",
+  "changelogUrl": "https://github.com/Ylianst/MeshCentral/blob/master/plugins/novnclauncher/CHANGELOG.md",
+  "configUrl": "https://raw.githubusercontent.com/Ylianst/MeshCentral/master/plugins/novnclauncher/config.json",
+  "downloadUrl": "https://github.com/Ylianst/MeshCentral/archive/refs/heads/master.zip",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Ylianst/MeshCentral.git"
+  },
+  "meshCentralCompat": ">=1.1.0",
+  "settings": {
+    "buttonLabel": "Custom Web-VNC",
+    "buttonTooltip": "Launch a noVNC session with custom parameters",
+    "appendDefaultName": true,
+    "hideDefaultWebVncLink": false,
+    "windowNamePrefix": "customnovnc",
+    "queryString": "",
+    "queryParameters": {
+      "autoconnect": "true"
+    }
+  }
+}

--- a/plugins/novnclauncher/novnclauncher.js
+++ b/plugins/novnclauncher/novnclauncher.js
@@ -1,0 +1,216 @@
+/**
+* MeshCentral noVNC launcher plugin
+* Adds a configurable button to the device view that opens a noVNC session with additional parameters.
+*/
+
+module.exports.novnclauncher = function (pluginHandler) {
+    const obj = {};
+    obj.parent = pluginHandler.parent;
+    obj.exports = ['onWebUIStartupEnd', 'onDeviceRefreshEnd', 'launchCustomNoVnc'];
+
+    const fs = pluginHandler.fs || require('fs');
+    const path = pluginHandler.path || require('path');
+
+    const defaults = {
+        buttonLabel: 'Custom Web-VNC',
+        buttonTooltip: 'Launch a noVNC session with custom parameters',
+        appendDefaultName: true,
+        hideDefaultWebVncLink: false,
+        windowNamePrefix: 'novnclauncher',
+        queryString: '',
+        queryParameters: { autoconnect: 'true' },
+        copyContextMenuFromWebVnc: true
+    };
+
+    let configSettings = {};
+    try {
+        const raw = fs.readFileSync(path.join(__dirname, 'config.json'));
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed.settings === 'object') {
+            configSettings = parsed.settings;
+        }
+    } catch (err) {
+        if (pluginHandler.parent && typeof pluginHandler.parent.debug === 'function') {
+            pluginHandler.parent.debug(1, 'noVNC launcher plugin: unable to read config.json (' + err + ')');
+        } else {
+            console.log('noVNC launcher plugin: unable to read config.json (' + err + ')');
+        }
+    }
+
+    const mergedSettings = Object.assign({}, defaults, configSettings || {});
+
+    if ((mergedSettings.queryParameters == null) || (typeof mergedSettings.queryParameters !== 'object') || Array.isArray(mergedSettings.queryParameters)) {
+        mergedSettings.queryParameters = {};
+    }
+    if (typeof mergedSettings.queryString !== 'string') {
+        mergedSettings.queryString = '';
+    }
+    if (typeof mergedSettings.buttonLabel !== 'string' || mergedSettings.buttonLabel.trim().length === 0) {
+        mergedSettings.buttonLabel = defaults.buttonLabel;
+    }
+    if (typeof mergedSettings.buttonTooltip !== 'string' || mergedSettings.buttonTooltip.trim().length === 0) {
+        mergedSettings.buttonTooltip = defaults.buttonTooltip;
+    }
+    if (typeof mergedSettings.windowNamePrefix !== 'string' || mergedSettings.windowNamePrefix.trim().length === 0) {
+        mergedSettings.windowNamePrefix = defaults.windowNamePrefix;
+    }
+    mergedSettings.appendDefaultName = (mergedSettings.appendDefaultName !== false);
+    mergedSettings.copyContextMenuFromWebVnc = (mergedSettings.copyContextMenuFromWebVnc !== false);
+
+    const clientSettings = {
+        buttonLabel: mergedSettings.buttonLabel,
+        buttonTooltip: mergedSettings.buttonTooltip,
+        appendDefaultName: mergedSettings.appendDefaultName,
+        hideDefaultWebVncLink: mergedSettings.hideDefaultWebVncLink === true,
+        windowNamePrefix: mergedSettings.windowNamePrefix,
+        queryString: mergedSettings.queryString,
+        queryParameters: mergedSettings.queryParameters,
+        copyContextMenuFromWebVnc: mergedSettings.copyContextMenuFromWebVnc
+    };
+
+    const settingsLiteral = JSON.stringify(clientSettings).replace(/\\/g, '\\\\').replace(/`/g, '\\`');
+
+    obj.onWebUIStartupEnd = new Function(`
+        var settings = ${settingsLiteral};
+        if (pluginHandler && pluginHandler.novnclauncher) {
+            pluginHandler.novnclauncher._clientSettings = settings;
+            if (typeof pluginHandler.novnclauncher._pendingNovnc === 'undefined') {
+                pluginHandler.novnclauncher._pendingNovnc = null;
+            }
+        }
+        if (!window.meshserver || window.meshserver._novnclauncherWrapped) { return; }
+        var originalOnMessage = window.meshserver.onMessage;
+        window.meshserver._novnclauncherWrapped = true;
+        window.meshserver.onMessage = function(server, message) {
+            if (message && message.action === 'getcookie' && message.tag === 'novnc') {
+                var pending = (pluginHandler && pluginHandler.novnclauncher) ? pluginHandler.novnclauncher._pendingNovnc : null;
+                if (pending) {
+                    pluginHandler.novnclauncher._pendingNovnc = null;
+                    try {
+                        var vncurl = window.location.origin + domainUrl + 'novnc/vnc.html?ws=wss%3A%2F%2F' + window.location.host + encodeURIComponentEx(domainUrl) + (message.localRelay ? 'local' : 'mesh') + 'relay.ashx%3Fauth%3D' + message.cookie + '&show_dot=1' + (urlargs.key ? ('&key=' + urlargs.key) : '') + '&l={{{lang}}}';
+                        if (settings.appendDefaultName !== false) {
+                            var node = getNodeFromId(message.nodeid);
+                            if (node != null && node.name != null) { vncurl += '&name=' + encodeURIComponentEx(node.name); }
+                        }
+                        if (pending.extraQuery) { vncurl += pending.extraQuery; }
+                        var targetWindow = pending.windowName || ('mcnovnc/' + message.nodeid);
+                        safeNewWindow(vncurl, targetWindow);
+                    } catch (novncErr) {
+                        console.error('noVNC launcher plugin could not open window', novncErr);
+                    }
+                    return;
+                }
+            }
+            return originalOnMessage.apply(this, arguments);
+        };
+    `);
+
+    obj.onDeviceRefreshEnd = new Function('nodeid', 'panel', 'refresh', 'event', `
+        var settings = ${settingsLiteral};
+        try {
+            var wrapperId = 'novnclauncher-link-wrapper';
+            var existingWrapper = document.getElementById(wrapperId);
+            if (existingWrapper && existingWrapper.parentNode) { existingWrapper.parentNode.removeChild(existingWrapper); }
+            var anchor = Q('rfbLink');
+            if (!anchor) { return; }
+            if (settings.hideDefaultWebVncLink === true) {
+                anchor.style.display = 'none';
+            } else {
+                anchor.style.display = '';
+            }
+            var container = anchor.parentNode || Q('p10html3left');
+            if (!container) { return; }
+            var link = document.createElement('a');
+            link.id = 'novnclauncher-link';
+            link.href = '#';
+            link.textContent = settings.buttonLabel || anchor.textContent || 'Web-VNC';
+            if (settings.buttonTooltip) { link.title = settings.buttonTooltip; }
+            if (settings.copyContextMenuFromWebVnc && anchor.getAttribute) {
+                var cmenuAttr = anchor.getAttribute('cmenu');
+                if (cmenuAttr) { link.setAttribute('cmenu', cmenuAttr); }
+            }
+            link.onclick = function(ev) {
+                if (ev) { ev.preventDefault(); }
+                if (pluginHandler && pluginHandler.novnclauncher && typeof pluginHandler.novnclauncher.launchCustomNoVnc === 'function') {
+                    pluginHandler.novnclauncher.launchCustomNoVnc(nodeid);
+                }
+                return false;
+            };
+            var wrapper = document.createElement('span');
+            wrapper.id = wrapperId;
+            wrapper.style.marginLeft = '6px';
+            wrapper.appendChild(link);
+            container.appendChild(wrapper);
+        } catch (ex) {
+            console.error('noVNC launcher plugin could not render button', ex);
+        }
+    `);
+
+    obj.launchCustomNoVnc = new Function('nodeid', `
+        var settings = ${settingsLiteral};
+        try {
+            var node = getNodeFromId(nodeid);
+            if (!node || !window.meshserver) { return false; }
+            var mesh = (typeof meshes !== 'undefined') ? meshes[node.meshid] : null;
+            var port = (node.rfbport != null) ? node.rfbport : 5900;
+            var addr = null;
+            var requestNodeId = nodeid;
+            if (node.mtype == 3 && mesh && mesh.relayid) { requestNodeId = mesh.relayid; addr = node.host; }
+            function applyTemplate(value) {
+                if (value == null) { return value; }
+                if (typeof value !== 'string') { return value; }
+                return value.replace(/\\{\\{([^}]+)\\}\\}/g, function(_m, token) {
+                    token = token.trim().toLowerCase();
+                    if (token === 'nodeid') { return node._id || ''; }
+                    if (token === 'name') { return node.name || ''; }
+                    if (token === 'hostname' || token === 'host') { return node.host || ''; }
+                    if (token === 'meshid') { return node.meshid || ''; }
+                    if (token === 'meshname' || token === 'group') { return (mesh && mesh.name) ? mesh.name : ''; }
+                    if (token === 'domainid') { return (mesh && mesh.domain) ? mesh.domain : ''; }
+                    var direct = node[token];
+                    if (direct === undefined || direct === null) { return ''; }
+                    if (typeof direct === 'object') { try { return JSON.stringify(direct); } catch (e) { return ''; } }
+                    return '' + direct;
+                });
+            }
+            function normalize(val) {
+                if (val === null || val === undefined) { return null; }
+                if (typeof val === 'boolean') { return val ? '1' : '0'; }
+                if (typeof val === 'number') { return '' + val; }
+                if (typeof val === 'string') { return applyTemplate(val); }
+                if (Array.isArray(val)) { return val.map(function(v) { return applyTemplate('' + v); }).join(','); }
+                if (typeof val === 'object') { return applyTemplate(JSON.stringify(val)); }
+                return applyTemplate('' + val);
+            }
+            var querySuffix = '';
+            if (typeof settings.queryString === 'string' && settings.queryString.length > 0) {
+                querySuffix += (settings.queryString.charAt(0) === '&' ? settings.queryString : '&' + settings.queryString);
+            }
+            if (settings.queryParameters && typeof settings.queryParameters === 'object') {
+                var parts = [];
+                for (var key in settings.queryParameters) {
+                    if (!Object.prototype.hasOwnProperty.call(settings.queryParameters, key)) { continue; }
+                    var value = normalize(settings.queryParameters[key]);
+                    if (value === null || value === undefined || value === '') { continue; }
+                    parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+                if (parts.length > 0) {
+                    querySuffix += '&' + parts.join('&');
+                }
+            }
+            if (pluginHandler && pluginHandler.novnclauncher) {
+                pluginHandler.novnclauncher._pendingNovnc = {
+                    nodeid: nodeid,
+                    extraQuery: querySuffix,
+                    windowName: (settings.windowNamePrefix || 'novnclauncher') + '/' + nodeid
+                };
+            }
+            window.meshserver.send({ action: 'getcookie', nodeid: requestNodeId, tcpport: port, tcpaddr: addr, tag: 'novnc', name: mesh ? mesh.name : null });
+        } catch (ex) {
+            console.error('noVNC launcher plugin failed to start session', ex);
+        }
+        return false;
+    `);
+
+    return obj;
+};


### PR DESCRIPTION
## Summary
- add the `novnclauncher` plugin that injects a configurable noVNC launch button in the device view
- allow templated query parameters, optional window name prefixes, and hiding of the built-in Web-VNC link
- document plugin installation, configuration, and changelog entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d53beb68a8832db258fada0c7417a4